### PR TITLE
Opt-in per-client event throttling (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,32 @@ Tools: `list_targets`, `attach`, `detach`, `cdp_send`
 
 Meta commands use `chrome-tap.*` namespace. Everything else passes through as raw CDP.
 
+## Event throttling
+
+Noisy domains (`Console.enable`, `Network.enable`) can emit 100k+ events and
+overwhelm a slow client. Throttling is **opt-in** — by default you get the raw
+firehose. Pass `eventThrottle` to `chrome-tap.attach`, mapping a CDP event
+method (or `"*"` wildcard) to a max events/sec:
+
+```json
+{"id":2,"method":"chrome-tap.attach","params":{
+  "tabId":123,
+  "eventThrottle":{"Console.messageAdded":50,"Network.dataReceived":100,"*":200}
+}}
+```
+
+Events over the cap (per 1s window, per method) are dropped newest-first. An
+explicit method overrides `"*"`. Drops are never silent — every 100ms the host
+sends a notice with the count dropped since the last flush:
+
+```json
+{"type":"event","method":"chrome-tap.throttled","params":{"dropped":{"Console.messageAdded":312}}}
+```
+
+A throttled client whose WS send buffer backs up past 4MB also has its events
+dropped (and counted) until the buffer drains, so one slow consumer can't stall
+the host.
+
 ## Config
 
 | Env var | Default | Description |

--- a/host/package.json
+++ b/host/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "ws": "^8.18.0"
   }

--- a/host/router.js
+++ b/host/router.js
@@ -2,6 +2,12 @@
 // Each WS client uses its own ID space. The router assigns internal IDs
 // and maps responses back to the correct client + original ID.
 
+const {
+  ClientThrottle,
+  FLUSH_MS,
+  BACKPRESSURE_BYTES
+} = require('./throttle');
+
 class Router {
   constructor(sendToExtension) {
     this._sendToExtension = sendToExtension;
@@ -9,6 +15,8 @@ class Router {
     this._pending = new Map(); // internalId -> { ws, originalId }
     this._clients = new Set();
     this._subscriptions = new Map(); // ws -> Set<tabId> (for event routing)
+    this._throttles = new Map(); // ws -> ClientThrottle (only when opted in)
+    this._flushTimer = null;
   }
 
   addClient(ws) {
@@ -20,6 +28,8 @@ class Router {
   removeClient(ws) {
     this._clients.delete(ws);
     this._subscriptions.delete(ws);
+    this._throttles.delete(ws);
+    if (this._throttles.size === 0) this._stopFlushTimer();
     // Clean up pending requests for this client
     for (const [id, entry] of this._pending) {
       if (entry.ws === ws) this._pending.delete(id);
@@ -34,16 +44,43 @@ class Router {
     // Track tab subscriptions for event routing
     if (msg.method === 'chrome-tap.attach' && msg.params?.tabId) {
       this._subscriptions.get(ws)?.add(msg.params.tabId);
+      this._applyThrottleConfig(ws, msg.params.eventThrottle);
     }
     if (msg.method === 'chrome-tap.detach' && msg.params?.tabId) {
       this._subscriptions.get(ws)?.delete(msg.params.tabId);
     }
 
+    // eventThrottle is a chrome-tap concern; don't leak it to the extension/CDP.
+    const params = this._stripThrottle(msg.params);
+
     this._sendToExtension({
       id: internalId,
       method: msg.method,
-      params: msg.params
+      params
     });
+  }
+
+  // Install (or clear) a per-client throttle from attach params. Passing an
+  // empty/omitted config leaves the client on the raw firehose (the default).
+  _applyThrottleConfig(ws, eventThrottle) {
+    if (eventThrottle && typeof eventThrottle === 'object') {
+      const throttle = new ClientThrottle(eventThrottle);
+      if (throttle.hasLimits()) {
+        this._throttles.set(ws, throttle);
+        this._startFlushTimer();
+        return;
+      }
+    }
+    this._throttles.delete(ws);
+    if (this._throttles.size === 0) this._stopFlushTimer();
+  }
+
+  _stripThrottle(params) {
+    if (!params || typeof params !== 'object' || !('eventThrottle' in params)) {
+      return params;
+    }
+    const { eventThrottle: _ignored, ...rest } = params;
+    return rest;
   }
 
   // Extension -> WS client (response)
@@ -66,15 +103,59 @@ class Router {
   // Extension -> all interested WS clients (event)
   handleExtensionEvent(msg) {
     const event = JSON.stringify(msg);
+    const now = Date.now();
     for (const ws of this._clients) {
       const subs = this._subscriptions.get(ws);
       // Send if client is subscribed to this tab, or if no tabId (broadcast)
-      if (!msg.tabId || subs?.has(msg.tabId)) {
-        try {
-          ws.send(event);
-        } catch (_) {
-          // Client disconnected
+      if (msg.tabId && !subs?.has(msg.tabId)) continue;
+
+      const throttle = this._throttles.get(ws);
+      if (throttle) {
+        // Drop when over the configured rate, or when the client's send
+        // buffer is backed up (slow consumer). Either way it's counted and
+        // surfaced via the next chrome-tap.throttled flush.
+        if (ws.bufferedAmount > BACKPRESSURE_BYTES) {
+          throttle.recordDrop(msg.method);
+          continue;
         }
+        if (!throttle.allow(msg.method, now)) continue;
+      }
+
+      try {
+        ws.send(event);
+      } catch (_) {
+        // Client disconnected
+      }
+    }
+  }
+
+  // --- Throttle drop reporting ---
+
+  _startFlushTimer() {
+    if (this._flushTimer) return;
+    this._flushTimer = setInterval(() => this._flushDropped(), FLUSH_MS);
+    if (typeof this._flushTimer.unref === 'function') this._flushTimer.unref();
+  }
+
+  _stopFlushTimer() {
+    if (!this._flushTimer) return;
+    clearInterval(this._flushTimer);
+    this._flushTimer = null;
+  }
+
+  _flushDropped() {
+    for (const [ws, throttle] of this._throttles) {
+      const dropped = throttle.drainDropped();
+      if (!dropped) continue;
+      const notice = JSON.stringify({
+        type: 'event',
+        method: 'chrome-tap.throttled',
+        params: { dropped }
+      });
+      try {
+        ws.send(notice);
+      } catch (_) {
+        // Client disconnected
       }
     }
   }

--- a/host/throttle.js
+++ b/host/throttle.js
@@ -1,0 +1,80 @@
+// Per-client event throttling for high-volume CDP domains.
+//
+// Throttling is opt-in: clients pass `eventThrottle` in chrome-tap.attach
+// params, mapping a CDP event method (or "*" wildcard) to a max events/sec.
+// Events over the cap inside a 1s sliding window are dropped (newest first).
+// Dropped counts are surfaced to the client via chrome-tap.throttled events
+// flushed on an interval, so no loss is silent.
+//
+//   chrome-tap.attach { tabId, eventThrottle: { "Console.messageAdded": 50, "*": 200 } }
+//
+// A separate backpressure guard drops events for any client whose WS send
+// buffer grows past BACKPRESSURE_BYTES, regardless of throttle config.
+
+const WINDOW_MS = 1000;
+const FLUSH_MS = 100;
+const BACKPRESSURE_BYTES = 4 * 1024 * 1024;
+
+class ClientThrottle {
+  // config: { method -> maxPerSec }, may include "*" wildcard. Empty => no limits.
+  constructor(config = {}) {
+    this._config = config;
+    this._counts = new Map(); // method -> { windowStart, count }
+    this._dropped = new Map(); // method -> dropped count since last flush
+  }
+
+  hasLimits() {
+    return Object.keys(this._config).length > 0;
+  }
+
+  _limitFor(method) {
+    if (Object.prototype.hasOwnProperty.call(this._config, method)) {
+      return this._config[method];
+    }
+    if (Object.prototype.hasOwnProperty.call(this._config, '*')) {
+      return this._config['*'];
+    }
+    return null; // unlimited
+  }
+
+  // Returns true if the event should be sent, false if it should be dropped.
+  allow(method, now = Date.now()) {
+    const limit = this._limitFor(method);
+    if (limit === null) return true;
+    if (limit <= 0) {
+      this._dropped.set(method, (this._dropped.get(method) || 0) + 1);
+      return false;
+    }
+
+    let bucket = this._counts.get(method);
+    if (!bucket || now - bucket.windowStart >= WINDOW_MS) {
+      bucket = { windowStart: now, count: 0 };
+      this._counts.set(method, bucket);
+    }
+
+    if (bucket.count < limit) {
+      bucket.count++;
+      return true;
+    }
+
+    this._dropped.set(method, (this._dropped.get(method) || 0) + 1);
+    return false;
+  }
+
+  // Record a drop not attributable to a rate window (e.g. backpressure).
+  recordDrop(method, n = 1) {
+    this._dropped.set(method, (this._dropped.get(method) || 0) + n);
+  }
+
+  // Returns { method -> droppedCount } accumulated since the last flush,
+  // and resets the counters. Returns null when nothing was dropped.
+  drainDropped() {
+    if (this._dropped.size === 0) return null;
+    const out = {};
+    for (const [method, count] of this._dropped) out[method] = count;
+    this._dropped.clear();
+    return out;
+  }
+}
+
+module.exports = { ClientThrottle, WINDOW_MS, FLUSH_MS, BACKPRESSURE_BYTES };

--- a/host/throttle.test.js
+++ b/host/throttle.test.js
@@ -1,0 +1,179 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ClientThrottle } = require('./throttle');
+const { Router } = require('./router');
+
+// --- ClientThrottle ---
+
+test('no config => unlimited firehose', () => {
+  const t = new ClientThrottle();
+  assert.equal(t.hasLimits(), false);
+  for (let i = 0; i < 1000; i++) {
+    assert.equal(t.allow('Console.messageAdded', 0), true);
+  }
+  assert.equal(t.drainDropped(), null);
+});
+
+test('per-method cap drops within the window and reports counts', () => {
+  const t = new ClientThrottle({ 'Console.messageAdded': 3 });
+  const now = 1000;
+  const sent = [];
+  for (let i = 0; i < 10; i++) {
+    sent.push(t.allow('Console.messageAdded', now));
+  }
+  assert.equal(sent.filter(Boolean).length, 3);
+  assert.deepEqual(t.drainDropped(), { 'Console.messageAdded': 7 });
+  // draining resets
+  assert.equal(t.drainDropped(), null);
+});
+
+test('window resets after WINDOW_MS', () => {
+  const t = new ClientThrottle({ 'Network.responseReceived': 2 });
+  assert.equal(t.allow('Network.responseReceived', 0), true);
+  assert.equal(t.allow('Network.responseReceived', 0), true);
+  assert.equal(t.allow('Network.responseReceived', 0), false);
+  // next window
+  assert.equal(t.allow('Network.responseReceived', 1000), true);
+});
+
+test('wildcard applies to unlisted methods, explicit overrides wildcard', () => {
+  const t = new ClientThrottle({ '*': 1, 'Console.messageAdded': 5 });
+  // wildcard: 1/window for an unlisted method
+  assert.equal(t.allow('Network.dataReceived', 0), true);
+  assert.equal(t.allow('Network.dataReceived', 0), false);
+  // explicit override: 5/window
+  for (let i = 0; i < 5; i++) {
+    assert.equal(t.allow('Console.messageAdded', 0), true);
+  }
+  assert.equal(t.allow('Console.messageAdded', 0), false);
+});
+
+test('zero limit drops everything', () => {
+  const t = new ClientThrottle({ 'Console.messageAdded': 0 });
+  assert.equal(t.allow('Console.messageAdded', 0), false);
+  assert.deepEqual(t.drainDropped(), { 'Console.messageAdded': 1 });
+});
+
+// --- Router integration ---
+
+// Minimal fake WS that records frames and reports a controllable bufferedAmount.
+function fakeWs() {
+  return {
+    sent: [],
+    bufferedAmount: 0,
+    _handlers: {},
+    on(ev, fn) { this._handlers[ev] = fn; },
+    send(data) { this.sent.push(JSON.parse(data)); }
+  };
+}
+
+function events(ws) {
+  return ws.sent.filter((m) => m.type === 'event' && m.method !== 'chrome-tap.throttled');
+}
+function throttledNotices(ws) {
+  return ws.sent.filter((m) => m.method === 'chrome-tap.throttled');
+}
+
+test('attach without eventThrottle leaves client unthrottled', () => {
+  const router = new Router(() => {});
+  const ws = fakeWs();
+  router.addClient(ws);
+  router.handleClientMessage(ws, { id: 1, method: 'chrome-tap.attach', params: { tabId: 7 } });
+
+  for (let i = 0; i < 50; i++) {
+    router.handleExtensionEvent({ type: 'event', tabId: 7, method: 'Console.messageAdded', params: {} });
+  }
+  assert.equal(events(ws).length, 50);
+});
+
+test('attach strips eventThrottle before forwarding to extension', () => {
+  const forwarded = [];
+  const router = new Router((m) => forwarded.push(m));
+  const ws = fakeWs();
+  router.addClient(ws);
+  router.handleClientMessage(ws, {
+    id: 1,
+    method: 'chrome-tap.attach',
+    params: { tabId: 7, eventThrottle: { 'Console.messageAdded': 5 } }
+  });
+  assert.equal('eventThrottle' in forwarded[0].params, false);
+  assert.equal(forwarded[0].params.tabId, 7);
+});
+
+test('throttled client only receives up to the cap and gets a drop notice', () => {
+  const router = new Router(() => {});
+  const ws = fakeWs();
+  router.addClient(ws);
+  router.handleClientMessage(ws, {
+    id: 1,
+    method: 'chrome-tap.attach',
+    params: { tabId: 7, eventThrottle: { 'Console.messageAdded': 5 } }
+  });
+
+  for (let i = 0; i < 20; i++) {
+    router.handleExtensionEvent({ type: 'event', tabId: 7, method: 'Console.messageAdded', params: {} });
+  }
+  assert.equal(events(ws).length, 5);
+
+  router._flushDropped();
+  const notices = throttledNotices(ws);
+  assert.equal(notices.length, 1);
+  assert.deepEqual(notices[0].params.dropped, { 'Console.messageAdded': 15 });
+
+  router.removeClient(ws);
+});
+
+test('backpressure drops events for a slow consumer', () => {
+  const router = new Router(() => {});
+  const ws = fakeWs();
+  router.addClient(ws);
+  router.handleClientMessage(ws, {
+    id: 1,
+    method: 'chrome-tap.attach',
+    params: { tabId: 7, eventThrottle: { '*': 1000 } }
+  });
+
+  ws.bufferedAmount = 8 * 1024 * 1024; // over BACKPRESSURE_BYTES
+  for (let i = 0; i < 10; i++) {
+    router.handleExtensionEvent({ type: 'event', tabId: 7, method: 'Network.dataReceived', params: {} });
+  }
+  assert.equal(events(ws).length, 0);
+
+  router._flushDropped();
+  assert.deepEqual(throttledNotices(ws)[0].params.dropped, { 'Network.dataReceived': 10 });
+
+  router.removeClient(ws);
+});
+
+test('throttle does not affect other clients on the same tab', () => {
+  const router = new Router(() => {});
+  const slow = fakeWs();
+  const fast = fakeWs();
+  router.addClient(slow);
+  router.addClient(fast);
+  router.handleClientMessage(slow, {
+    id: 1, method: 'chrome-tap.attach', params: { tabId: 7, eventThrottle: { 'Console.messageAdded': 2 } }
+  });
+  router.handleClientMessage(fast, {
+    id: 1, method: 'chrome-tap.attach', params: { tabId: 7 }
+  });
+
+  for (let i = 0; i < 10; i++) {
+    router.handleExtensionEvent({ type: 'event', tabId: 7, method: 'Console.messageAdded', params: {} });
+  }
+  assert.equal(events(slow).length, 2);
+  assert.equal(events(fast).length, 10);
+});
+
+test('removeClient stops the flush timer when no throttles remain', () => {
+  const router = new Router(() => {});
+  const ws = fakeWs();
+  router.addClient(ws);
+  router.handleClientMessage(ws, {
+    id: 1, method: 'chrome-tap.attach', params: { tabId: 7, eventThrottle: { '*': 10 } }
+  });
+  assert.notEqual(router._flushTimer, null);
+  router.removeClient(ws);
+  assert.equal(router._flushTimer, null);
+});


### PR DESCRIPTION
Closes #1.

## What

Opt-in, per-client event throttling for high-volume CDP domains. By default nothing changes — clients still get the raw firehose. A client opts in by passing `eventThrottle` to `chrome-tap.attach`:

```json
{"id":2,"method":"chrome-tap.attach","params":{
  "tabId":123,
  "eventThrottle":{"Console.messageAdded":50,"Network.dataReceived":100,"*":200}
}}
```

Values are max events/sec per method (`"*"` is a wildcard; an explicit method overrides it). Events over the cap inside a 1s window are dropped newest-first.

Drops are never silent. Every 100ms the host emits a notice with per-method counts since the last flush:

```json
{"type":"event","method":"chrome-tap.throttled","params":{"dropped":{"Console.messageAdded":312}}}
```

A throttled client whose WS send buffer backs up past 4MB also has its events dropped (and counted) until it drains — router-side backpressure so one slow consumer can't stall the host.

## Approach / scope

The issue listed four candidate approaches. This implements the two that live entirely host-side and need no extension reload or Team-tier config:
- **Client-configurable throttle** (the explicitly-spec'd `eventThrottle` on attach).
- **Router-side backpressure** with a surfaced dropped count.

Extension-side ring buffering and array-batching were left out deliberately — batching would change the wire format (events become arrays) and touch the MV3 service worker; worth its own issue if the host-side limits prove insufficient.

Throttle state is per WS client, so throttling one client never affects another subscribed to the same tab. `eventThrottle` is stripped before commands are forwarded to the extension/CDP.

## Files

- `host/throttle.js` — `ClientThrottle` (sliding window, wildcard, drop accounting).
- `host/router.js` — applies throttle + backpressure in the event fan-out; flush timer for `chrome-tap.throttled`; strips `eventThrottle` on attach.
- `host/throttle.test.js` — 11 tests via the built-in `node:test` runner (zero new deps).
- `host/package.json` — adds `npm test`.
- `README.md` — documents the opt-in throttle.

## Verification

- `node --check` clean on every `host/*.js`.
- `cd host && npm test` → 11 passing, 0 failing.

No lint/typecheck tooling exists in the repo (vanilla CommonJS, no eslint/prettier/tsconfig), so syntax check + tests are the bar. No pre-existing warnings to baseline against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)